### PR TITLE
fixing AC check so it pulls down multiple lines

### DIFF
--- a/01_scripts/06_annotate_transcriptome.py
+++ b/01_scripts/06_annotate_transcriptome.py
@@ -50,7 +50,10 @@ class Info(object):
             with open(info_file) as ifile:
                 for line in ifile:
                     if line.startswith("AC"):
-                        self.accession = get_info(line)
+                        if len(self.accession) == 0:
+                            self.accession = get_info(line)
+                        else:
+                            self.accession = self.accession + " " + get_info(line)
                     elif line.startswith("DE   RecName: Full="):
                         l = line.replace("DE   RecName: Full=", "").strip()
                         l = l.replace(";", "")

--- a/01_scripts/06_annotate_transcriptome.py
+++ b/01_scripts/06_annotate_transcriptome.py
@@ -50,7 +50,7 @@ class Info(object):
             with open(info_file) as ifile:
                 for line in ifile:
                     if line.startswith("AC"):
-                        if len(self.accession) == 0:
+                        if not self.accession:
                             self.accession = get_info(line)
                         else:
                             self.accession = self.accession + " " + get_info(line)


### PR DESCRIPTION
There are cases in uniprot where the AC ids occupies more than one line, for example, [here](https://www.uniprot.org/uniprot/Q02548.txt). As the script is currently written, it overwrites the first line of AC and only writes out the 2nd line. The first occurrence of AC includes the primary accession. I've changed things so it checks that the accession is empty before overwriting it. If it isn't empty, appends instead. I believe this fixes the issue.
